### PR TITLE
feat: Add top k frequent elements ruby solution

### DIFF
--- a/ruby/arrays/347-top-k-frequent-elements.rb
+++ b/ruby/arrays/347-top-k-frequent-elements.rb
@@ -1,0 +1,33 @@
+# @param {Integer[]} nums
+# @param {Integer} k
+# @return {Integer[]}
+def top_k_frequent(nums, k)
+    frequency_map = Hash.new(0)
+    result = []
+    max_frequency = 1
+
+    nums.each do |num|
+        frequency_map[num] += 1
+        curr_frequency = frequency_map[num]
+        max_frequency = curr_frequency if curr_frequency > max_frequency
+    end
+
+    reversed = Hash.new { |h, k| h[k] = [] }
+
+    frequency_map.each do |key, value|
+        reversed[value] << key
+    end
+
+    while k - result.length > 0 do
+        values = reversed[max_frequency]
+
+        if values.length <= k - result.length
+            result += values
+        else
+            result += values.slice(0, k - result.length)
+        end
+         max_frequency -= 1
+    end
+
+    result
+end


### PR DESCRIPTION
### 🧠 Problem

<!-- Add the problem link and brief description -->
[LeetCode #347 ](https://leetcode.com/problems/top-k-frequent-elements/)

---

### 🧪 Languages Implemented

- [x] Ruby: `ruby/arrays/top-k-frequent-elements.rb`
- [ ] Python: `python/<topic>/<problem>.py`

---

### ✅ Approach

Used three loops:
1. construct hash with number as key and frequency as value, and also find max frequency
2. reverse the constructed hash
3. while loop to arrive at the result with sliced k elements in the result

Time Complexity:
  Value: O(n + u + k) => O(n)
  Breakdown:
    1. frequency_map construction O(n)
    2. reversed map construction O(u)
    3. Final while loop O(k)
Space Complexity: 
  Value: O(n + n + k + 1) => O(n)
  Breakdown:
    1. frequency_map O(n)
    2. reversed O(n)
    3. result O(k)
    4. max_frequency O(1)

---

### 🧹 Notes

<!-- Optional: Edge cases, improvements, test coverage, etc. -->
